### PR TITLE
removed deprecated get_magic_quotes_gpc uses

### DIFF
--- a/shared.php
+++ b/shared.php
@@ -32,7 +32,6 @@
 $app = \pff\Core\ServiceContainer::get('app');
 $app->setUrl($url);
 $app->setErrorReporting();
-$app->removeMagicQuotes();
 $app->unregisterGlobals();
 
 \pff\Core\ServiceContainer::get('modulemanager')->initModules();

--- a/src/App.php
+++ b/src/App.php
@@ -102,18 +102,6 @@ class App {
     }
 
     /**
-     * Removes magic quotes from requests
-     * @codeCoverageIgnore
-     */
-    public function removeMagicQuotes() {
-        if (get_magic_quotes_gpc()) {
-            $_GET    = $this->stripSlashesDeep($_GET);
-            $_POST   = $this->stripSlashesDeep($_POST);
-            $_COOKIE = $this->stripSlashesDeep($_COOKIE);
-        }
-    }
-
-    /**
      * Check register globals and remove them
      *
      * @codeCoverageIgnore


### PR DESCRIPTION
removed deprecated get_magic_quotes_gpc uses for compatibility with newer php version